### PR TITLE
Docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.env
+*.swp
 .vscode
 
 # Backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+from python:3.8
+
+WORKDIR /var/app
+
+COPY requirements.txt /var/app/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY . /var/app
+CMD python manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+    django:
+        build:
+            context: ./backend
+        ports:
+            - 8000:8000
+        volumes:
+            - ./backend:/var/app
+    frontend:
+        build:
+            context: ./frontend
+        ports:
+            - 3080:3000
+        volumes:
+            - ./frontend:/var/app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14
+
+WORKDIR /var/app
+
+COPY package.json /var/app/package.json
+RUN yarn install
+
+COPY . /var/app
+CMD yarn dev


### PR DESCRIPTION
This PR adds a very crude docker configuration. I just wanted to try out the app and was having problems with my wonky OSX python setup, so I set up a config to run it in docker instead.

It's very basic and has several issues, but since I did it I thought I'd submit it and we can iterate on it in the future.

Some flaws that should be fixed at some point:

* ~The sqlite database is not persistent across runs~ (EDIT: it actually is, but won't be when the next item is fixed)
* The source code is mounted as a volume by default, should only be in development
* There are no instructions in the README (which will still change rapidly anyway)

With this config, the following should be possible:

```
$ docker-compose up --build -d # Or without -d and run the rest in another terminal
$ docker-compose exec django python manage.py migrate
$ docker-compose exec django python manage.py createsuperuser
```

The back-end will then be exposed on localhost:8000 and front-end on localhost:3080 (not 3000 by default, which is already used by Gen 3 which many developers will run in parallel).

@djbusstop You can of course continue working in your regular environment without caring about the docker config.